### PR TITLE
Add a __syncthreads() call to prevent a race condition in NTT/NTTInv

### DIFF
--- a/cufhe/include/ntt_gpu/ntt_1024_device.cuh
+++ b/cufhe/include/ntt_gpu/ntt_1024_device.cuh
@@ -37,6 +37,7 @@ void NTT1024Core(FFP* r,
                  const uint32_t& t1d,
                  const uint3& t3d) {
   FFP *ptr = nullptr;
+  __syncthreads();
   #pragma unroll
   for (int i = 0; i < 8; i ++)
     r[i] *= twd_sqrt[(i << 7) | t1d]; // mult twiddle sqrt
@@ -88,6 +89,7 @@ void NTTInv1024Core(FFP* r,
                     const uint3& t3d) {
 
   FFP *ptr = nullptr;
+  __syncthreads();
   NTTInv8(r);
   NTTInv8x2Lsh(r, t3d.z); // if (t1d >= 64) NTT8x2<1>(r);
   ptr = &s[(t3d.y << 7) | (t3d.z << 6) | (t3d.x << 2)];

--- a/cufhe/lib/bootstrap_gpu.cu
+++ b/cufhe/lib/bootstrap_gpu.cu
@@ -196,7 +196,8 @@ void Accumulate(Torus* tlwe,
     FFP* tar = sh_acc_ntt[tid >> 7];
     ntt.NTT<FFP>(tar, tar, tar, tid >> 7 << 7);
   }
-  else { // must meet 3 sync made by NTTInv
+  else { // must meet 4 sync made by NTTInv
+    __syncthreads();
     __syncthreads();
     __syncthreads();
     __syncthreads();
@@ -227,7 +228,8 @@ void Accumulate(Torus* tlwe,
     FFP* src = sh_res_ntt[tid >> 7];
     ntt.NTTInvAdd<Torus>(&tlwe[tid >> 7 << 10], src, src, tid >> 7 << 7);
   }
-  else { // must meet 3 sync made by NTTInv
+  else { // must meet 4 sync made by NTTInv
+    __syncthreads();
     __syncthreads();
     __syncthreads();
     __syncthreads();


### PR DESCRIPTION
Fixes #3 (hopefully).

Logically, there should be another sync necessary at the end of `NTT1024Core()`/`NTTInv1024Core()`, because the shared memory is read and written with a different pattern in the end of the function and at the beginning of the parent one, but tests seem to show that the error disappears even without it.