### PR TITLE
Fix ksk_entry leak

### DIFF
--- a/cufhe/lib/bootstrap_cpu.cc
+++ b/cufhe/lib/bootstrap_cpu.cc
@@ -158,6 +158,7 @@ void Bootstrap(LWESample* out,
     }
   }
 
+  delete ksk_entry;
   for (int i = 0; i < kpl; i ++)
     delete [] decomp[i];
   delete [] decomp;


### PR DESCRIPTION
`ksk_entry` wasn't deallocated