### PR TITLE
Fixed Ctxt::lee_sample_device_ not nullptr in CPU mode.

### DIFF
--- a/cufhe/lib/cufhe_cpu.cc
+++ b/cufhe/lib/cufhe_cpu.cc
@@ -33,6 +33,8 @@ Ctxt::Ctxt(bool is_alias) {
   pair = AllocatorCPU::New(lwe_sample_->SizeMalloc());
   lwe_sample_->set_data((LWESample::PointerType)pair.first);
   lwe_sample_deleter_ = pair.second;
+  lwe_sample_device_ = nullptr;
+  lwe_sample_device_deleter_ = nullptr;
 }
 
 } // namespace cufhe


### PR DESCRIPTION
#10 Fixed.